### PR TITLE
Add static web UI to inspect assessment submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Fast, minimal backend for your GPT Actions–driven **Control Engineer Assessmen
 - **POST** `/submit_answer` – record a single answer + model assessment
 - **GET** `/results` – fetch rollup when enough answers are in
 - **GET** `/healthz` – health check
+- **GET** `/` – lightweight HTML page for manual testing
 
 ## Quick start (local)
 ```bash
@@ -11,6 +12,7 @@ python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 export API_KEY=dev-key   # set your real key in prod
 uvicorn main:app --reload
+# open http://127.0.0.1:8000/ in a browser for a simple web UI
 # test:
 curl -H "x-api-key: $API_KEY" http://127.0.0.1:8000/healthz
 ```

--- a/main.py
+++ b/main.py
@@ -1,11 +1,16 @@
 import os
+from pathlib import Path
 from typing import Optional, Dict, Any, List
+
 from fastapi import FastAPI, Header, HTTPException
+from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 API_KEY = os.getenv("API_KEY", "dev-key")
 
 app = FastAPI(title="Control Assessment API", version="1.0.1")
+
+BASE_DIR = Path(__file__).resolve().parent
 
 # Simple in-memory store; replace with a DB for production
 DB: Dict[str, List[Dict[str, Any]]] = {}
@@ -21,6 +26,12 @@ class Submit(BaseModel):
 def require_auth(x_api_key: Optional[str] = Header(None)):
     if x_api_key != API_KEY:
         raise HTTPException(status_code=401, detail="invalid api key")
+
+
+@app.get("/", include_in_schema=False)
+def index():
+    """Serve a tiny static page for manual testing."""
+    return FileResponse(BASE_DIR / "static" / "index.html")
 
 @app.get("/healthz")
 def healthz():

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Control Assessment Viewer</title>
+  <style>
+    body { font-family: sans-serif; max-width: 800px; margin: auto; }
+    textarea { width: 100%; height: 4em; }
+    pre { background: #f0f0f0; padding: 1em; }
+    section { margin-bottom: 2em; }
+  </style>
+</head>
+<body>
+  <h1>Control Assessment API Demo</h1>
+
+  <section id="submit">
+    <h2>Submit Answer</h2>
+    <form id="submit-form">
+      <label>API Key: <input type="text" id="submit-key" /></label><br />
+      <label>Assessment ID: <input type="text" id="assessment-id" /></label><br />
+      <label>Question ID: <input type="text" id="question-id" /></label><br />
+      <label>Answer Text:<br />
+        <textarea id="answer-text"></textarea>
+      </label><br />
+      <label>Model Score: <input type="number" step="0.01" id="model-score" /></label><br />
+      <label>Difficulty:
+        <select id="difficulty">
+          <option value="">(optional)</option>
+          <option value="basic">basic</option>
+          <option value="intermediate">intermediate</option>
+          <option value="advanced">advanced</option>
+        </select>
+      </label><br />
+      <button type="submit">Submit</button>
+    </form>
+    <pre id="submit-output"></pre>
+  </section>
+
+  <section id="results">
+    <h2>Fetch Results</h2>
+    <form id="results-form">
+      <label>API Key: <input type="text" id="results-key" /></label><br />
+      <label>Assessment ID: <input type="text" id="results-assessment-id" /></label><br />
+      <label>Include Details? <input type="checkbox" id="include-details" /></label><br />
+      <button type="submit">Get Results</button>
+    </form>
+    <pre id="results-output"></pre>
+  </section>
+
+  <script>
+    document.getElementById('submit-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const key = document.getElementById('submit-key').value;
+      const payload = {
+        assessment_id: document.getElementById('assessment-id').value,
+        question_id: document.getElementById('question-id').value,
+        answer_text: document.getElementById('answer-text').value,
+        model_score: parseFloat(document.getElementById('model-score').value),
+        meta: {}
+      };
+      const diff = document.getElementById('difficulty').value;
+      if (diff) payload.meta.difficulty = diff;
+      const res = await fetch('/submit_answer', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': key
+        },
+        body: JSON.stringify(payload)
+      });
+      document.getElementById('submit-output').textContent = await res.text();
+    });
+
+    document.getElementById('results-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const key = document.getElementById('results-key').value;
+      const id = document.getElementById('results-assessment-id').value;
+      const include = document.getElementById('include-details').checked;
+      const res = await fetch(`/results?assessment_id=${encodeURIComponent(id)}&include_details=${include}`, {
+        headers: {
+          'x-api-key': key
+        }
+      });
+      document.getElementById('results-output').textContent = await res.text();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Serve a simple static HTML page at the root path for manual interaction with the API
- Provide forms to submit answers and fetch results via JavaScript
- Document the new page and usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689b93fbbed4832b9f82c893da5c4ea0