### PR TITLE
fix: update OpenAPI server URL and make API key optional

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,8 @@ from fastapi import FastAPI, Header, HTTPException
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
-API_KEY = os.getenv("API_KEY", "dev-key")
+# When API_KEY is unset, auth checks are skipped.
+API_KEY = os.getenv("API_KEY")
 
 app = FastAPI(title="Control Assessment API", version="1.0.1")
 
@@ -24,7 +25,7 @@ class Submit(BaseModel):
     meta: Optional[Dict[str, Any]] = None
 
 def require_auth(x_api_key: Optional[str] = Header(None)):
-    if x_api_key != API_KEY:
+    if API_KEY and x_api_key != API_KEY:
         raise HTTPException(status_code=401, detail="invalid api key")
 
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,13 +4,16 @@ info:
   version: "1.0.1"
   description: Endpoints for posting answers and retrieving assessment results.
 servers:
-  - url: https://YOUR-SERVICE.koyeb.app   # <-- Change to your deployed HTTPS base URL
+  - url: https://valid-brandea-boathousevending-ce31ef07.koyeb.app
+# To require an API key, uncomment the security block below and add
+# `security` entries on the operations that should be protected.
+# security:
+#   - ApiKeyAuth: []
 paths:
   /submit_answer:
     post:
       operationId: submitAnswer
       description: Receive one answer + the model’s scoring/notes.
-      security: [{ ApiKeyAuth: [] }]
       requestBody:
         required: true
         content:
@@ -29,7 +32,6 @@ paths:
     get:
       operationId: getResults
       description: Get rollup when enough questions are answered.
-      security: [{ ApiKeyAuth: [] }]
       parameters:
         - in: query
           name: assessment_id


### PR DESCRIPTION
## Summary
- set OpenAPI server URL to deployed Koyeb domain
- define API key scheme but leave auth optional with guidance to enable
- skip API key checks in app unless `API_KEY` env var is set

## Testing
- `python -m py_compile $(git ls-files '*.py') && echo compiled`
- `python - <<'PY'
import yaml
with open('openapi.yaml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`


------
https://chatgpt.com/codex/tasks/task_e_689b99c3a3d0832bbdfcf07085a6d09a